### PR TITLE
Fix 'whatsapp' KeyError Issue

### DIFF
--- a/QRLJacker/core/browser.py
+++ b/QRLJacker/core/browser.py
@@ -66,7 +66,7 @@ class headless_browsers:
             new_headless[module_name]["Controller"] = None
             caps = DesiredCapabilities.FIREFOX.copy()
             # Disabling the new Firefox driver called marionette so it won't override geckodriver
-            caps['marionette'] = False
+            # caps['marionette'] = False
             caps['binary_location'] = self.browser_path
             if Settings.debug:
                 new_headless[module_name]["Controller"] = Firefox(profile, executable_path="/usr/local/share/geckodriver", capabilities=caps)#options=self.opts) # Inserting the browser object


### PR DESCRIPTION
- By forcefully setting "marionette" to false through DesiredCapabilities class you won't be able to open Mozilla Firefox Browser above version 48.x.

- The fix was tested on `Mozilla Firefox 78.4.1esr` and using `geckodriver-v0.28.0-linux64` Operation System `Debian 4.19.37-5+deb10u1`, `Python 3.7.3`

![Screenshot_2](https://user-images.githubusercontent.com/43918685/98897913-19796a00-24b5-11eb-8463-7ddbf4853888.png)


Fixes #125 
Fixes #124 
Fixes #37 
Fixes #114