### PR TITLE
Updated Error message on line 13

### DIFF
--- a/QRLJacker/QrlJacker.py
+++ b/QRLJacker/QrlJacker.py
@@ -10,7 +10,7 @@ if ( py_ver.major==3 and py_ver.minor<7 ):
     exit(0)
 
 elif os.name=="nt":
-    error("The framework is designed to work on linux or windows only! Sorry for that :)")
+    error("The framework is designed to work on linux or mac only! Sorry for that :)")
     exit(0)
 
 from core import Cli,utils,Settings,db


### PR DESCRIPTION
The script was checking if the operating system is windows `elif os.name=="nt":` and then showing the message that The framework is designed to work on linux or `windows` only!

I changed it to `error("The framework is designed to work on linux or mac only! Sorry for that :)")`