### PR TITLE
Fixing library version issues

### DIFF
--- a/QRLJacker/requirements.txt
+++ b/QRLJacker/requirements.txt
@@ -1,5 +1,7 @@
 terminaltables>=3.1.0
-selenium>=3.141.0
+selenium==3.141.0
+urllib3==1.26.15
+requests==2.28.2
 Pillow>=5.4.1
 Jinja2>=2.10
 user-agent>=0.1.9


### PR DESCRIPTION
```bash
pip install selenium==3.141.0 urllib3==1.26.15 requests==2.28.2
```

```console
Exception: Timeout value connect was <object object at 0x74de636487e0>, but it must be an int, float or None.
...
[!] Couldn't open Firefox! Check the installation instructions again!
```